### PR TITLE
NB1: Restart qcrild on data switch

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -480,6 +480,17 @@ on property:persist.vendor.radio.atfwd.start=false
 on property:vendor.radio.atfwd.start=false
     stop vendor.atfwd
 
+on property:persist.sys.radio.mobile_data_swap=1
+    restart vendor.qcrild
+    exec /bin/sleep 2
+    restart vendor.qcrild2
+
+service qcom-c_main-sh /vendor/bin/init.class_main.sh
+    class main
+    user root
+    group root system
+    oneshot
+
 on property:vendor.bluetooth.dun.status=running
     start vendor.bt-dun
 


### PR DESCRIPTION
No need to reboot device everytime to get internet back on every sim slot switch for data.
Kanged from rova.